### PR TITLE
KH-99: Rename "Adult NCD Consultation" form to "NCD Consultation"

### DIFF
--- a/configs/openmrs_config/ampathforms/adult_NCD_Consultation.json
+++ b/configs/openmrs_config/ampathforms/adult_NCD_Consultation.json
@@ -1,10 +1,10 @@
 {
-	"name": "ការពិគ្រោះយោបល់ជំងឺមិនឆ្លង សម្រាប់មនុស្សពេញវ័យ (Adult NCD Consultation)",
-	"description": "ការពិគ្រោះយោបល់ជំងឺមិនឆ្លង សម្រាប់មនុស្សពេញវ័យ (Adult NCD Consultation)",
+	"name": "ការពិគ្រោះយោបល់ជំងឺមិនឆ្លង (NCD Consultation)",
+	"description": "ការពិគ្រោះយោបល់ជំងឺមិនឆ្លង (NCD Consultation)",
 	"version": "1",
 	"published": true,
 	"retired": false,
-	"encounter": "Adult NCD Consultation",
+	"encounter": "NCD Consultation",
 	"processor": "EncounterFormProcessor",
 	"uuid": "xxxx",
 	"referencedForms": [],

--- a/configs/openmrs_config/encountertypes/encountertypes_core.csv
+++ b/configs/openmrs_config/encountertypes/encountertypes_core.csv
@@ -11,7 +11,7 @@ d7151f82-c1f3-4152-a605-2f9ea7414a79,,Visit Note,,,"Encounter where a full or ab
 5021b1a1-e7f6-44b4-ba02-da2f2bcf8718,,Attachment Upload,,,Encounters used to record uploads of attachments.,,,,
 3596fafb-6f6f-4396-8c87-6e63a0f1bd71,,Lab Results,,,Encounter for capturing lab results,,,,
 39da3525-afe4-45ff-8977-c53b7b359158,,Order,,,Encounter for capturing orders,,,,
-b870b6bb-9441-4664-9087-3d3477174213,,Adult NCD Consultation,Adult NCD Consultation,ការពិគ្រោះយោបល់ជំងឺមិនឆ្លង សម្រាប់មនុស្សពេញវ័យ,,,,,
+b870b6bb-9441-4664-9087-3d3477174213,,NCD Consultation,NCD Consultation,ការពិគ្រោះយោបល់ជំងឺមិនឆ្លង,,,,,
 f9fdbe63-12b4-479f-b8fd-dcbfde6aa944,,Adult NCD Registration,Adult NCD Registration,ទម្រង់ពិនិត្យស្រាវជ្រាវរុករកជំងឺមិនឆ្លង សម្រាប់មនុស្សពេញវ័យ,,,,,
 422b7e0c-b8f3-4748-8e60-d6684315f141,,Health Center - NCD Screening,Health Center - NCD Screening,ពិនិត្យស្វែងរកជំងឺមិនឆ្លងនៅមណ្ឌលសុខភាព,,,,,
 3fd606b6-4c9d-4077-a532-c1ac58644ad2,,Cervical Cancer Screening,Cervical Cancer Screening,ការពិនិត្យស្រាវជ្រាវរកជំងឺមហារីកមាត់ស្បូន,,,,,


### PR DESCRIPTION
In this PR, we renamed the "Adult NCD Consultation" form to "NCD Consultation"
See the output in the SS below
![ncd_cons](https://user-images.githubusercontent.com/67123286/227156395-232632d4-d144-475d-a5bd-6b1b07fe5677.png)
