### PR TITLE
KH-100: Rename Past Medical History to Medical History

### DIFF
--- a/configs/openmrs_config/ampathforms/adult_NCD_Registration.json
+++ b/configs/openmrs_config/ampathforms/adult_NCD_Registration.json
@@ -38,11 +38,11 @@
             ]
         },
         {
-            "label": "ប្រវត្តិជំងឺ (Past Medical History)",
+            "label": "ប្រវត្តិជំងឺ (Medical History)",
             "sections": [
                 {
                     "isExpanded": "true",
-                    "label": "ប្រវត្តិជំងឺ (Past Medical History)",
+                    "label": "ប្រវត្តិជំងឺ (Medical History)",
                     "questions": [
                         {
                             "id": "diagnosedForDM",

--- a/configs/openmrs_config/ampathforms/health_center_NCD_Screening.json
+++ b/configs/openmrs_config/ampathforms/health_center_NCD_Screening.json
@@ -75,11 +75,11 @@
             ]
         },
         {
-            "label": "ប្រវត្តិជំងឺ (Past Medical History)",
+            "label": "ប្រវត្តិជំងឺ (Medical History)",
             "sections": [
                 {
                     "isExpanded": "true",
-                    "label": "ប្រវត្តិជំងឺ (Past Medical History)",
+                    "label": "ប្រវត្តិជំងឺ (Medical History)",
                     "questions": [
                         {
                             "id": "knownHypertensive",


### PR DESCRIPTION
In this PR we have renamed the Past Medical History to Medical History in both the Adult NCD Registration and the Health Center - NCD Screening forms. See SS below.
![mh](https://user-images.githubusercontent.com/67123286/227199187-c417995d-b2d6-4f52-b65b-be6145d1674e.png)
