### PR TITLE
Fixed typo in name of HbA1c test 

### DIFF
--- a/configs/openmrs_config/ampathforms/NCD_Consultation.json
+++ b/configs/openmrs_config/ampathforms/NCD_Consultation.json
@@ -157,7 +157,7 @@
 							"validators": []
 						},
 						{
-                            "id": "HBA1c",
+                            "id": "HbA1c",
                             "questionOptions": {
                                 "rendering": "number",
                                 "concept": "a8af7520-1350-11df-a1f1-0026b9348838",

--- a/configs/openmrs_config/ampathforms/NCD_Screening.json
+++ b/configs/openmrs_config/ampathforms/NCD_Screening.json
@@ -330,7 +330,7 @@
                             "validators": []
                         },
                         {
-                            "id": "HBA1c",
+                            "id": "HbA1c",
                             "questionOptions": {
                                 "rendering": "number",
                                 "concept": "a8af7520-1350-11df-a1f1-0026b9348838",

--- a/configs/openmrs_config/concepts/labs.csv
+++ b/configs/openmrs_config/concepts/labs.csv
@@ -4,7 +4,7 @@ f52d731e-58da-4f3a-a480-77c5e9d8d2eb,,,Random Blood Sugar,រកកម្រិ�
 f5f76f5e-2e6a-4112-ab4e-629299829ae3,,,Total Cholestrol,កូលេស្តេរ៉ុលសរុប,Total Cholestrol,កូលេស្តេរ៉ុលសរុប,0,900,mg/dl,,,Test,Numeric,,,,
 c423325e-be95-42e2-ae38-b940c2586327,,,Albumin (Urine),តេស្តអាលប៊ុយម៊ីន (ក្នុងទឹកនោម),Albumin (Urine),តេស្តអាលប៊ុយម៊ីន (ក្នុងទឹកនោម),0,90,mg/g,,,Test,Text,,,,
 07015405-c865-4a22-8ad1-c8863d5f005b,,,Ketones (Urine),ពិនិត្យរកសារជាតិកេតូន (ក្នុងទឹកនោម),Ketones (Urine),ពិនិត្យរកសារជាតិកេតូន (ក្នុងទឹកនោម),0,9,mmol/L,,,Test,Text,,,,
-a8af7520-1350-11df-a1f1-0026b9348838,,,HBA1c,អេម៉ូក្លូប៊ីនអេវ័នស៊ី,HBA1c,អេម៉ូក្លូប៊ីនអេវ័នស៊ី,0,20,%,,,Test,Numeric,,,,
+a8af7520-1350-11df-a1f1-0026b9348838,,,HbA1c,អេម៉ូក្លូប៊ីនអេវ័នស៊ី,HbA1c,អេម៉ូក្លូប៊ីនអេវ័នស៊ី,0,20,%,,,Test,Numeric,,,,
 163594AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,,,OGTT,តេស្តកម្រិតជាតិស្ករក្នុងឈាម២ម៉ោងក្រោយផឹកទឹកស្ករ៧៥ក្រាម,OGTT,តេស្តកម្រិតជាតិស្ករក្នុងឈាម២ម៉ោងក្រោយផឹកទឹកស្ករ៧៥ក្រាម,20,450,mg/dl,,,Test,Numeric,,,,
 0bf33271-d553-42ae-a854-624e5258551d,,,Low-density lipoprotein,កូលេស្តេរ៉ុល LDL,LDL,កូលេស្តេរ៉ុល LDL,0,300,mg/dl,,,Test,Numeric,,,,
 a5d68184-6849-4a1d-9a86-5bcea3297f70,,,High-density lipoprotein,កូលេស្តេរ៉ុល HDL,HDL,កូលេស្តេរ៉ុល HDL,1,200,mg/dl,,,Test,Numeric,,,,


### PR DESCRIPTION



[HbA1c_fix_typo.webm](https://user-images.githubusercontent.com/36139599/230179223-6a502a51-499a-449d-a415-8bf5e1e75ff4.webm)
