### PR TITLE
KH-155: Exclude Reference Demo Data module

### DIFF
--- a/dependency-excludes-prod.txt
+++ b/dependency-excludes-prod.txt
@@ -1,0 +1,5 @@
+#
+# Escaped regex pattern. Supports multiple lines.
+#
+\.\*openmrs_modules.\*referencedemodata.\*
+

--- a/exclude-files.sh
+++ b/exclude-files.sh
@@ -1,19 +1,21 @@
 #!/usr/bin/env bash
 
-targetDir=$1
+exclusionFileName=$1
+targetDir=$2
 
-cat dependency-excludes.txt | while read line || [ -n "$line" ]
+echo "Parsing '$exclusionFileName' to identify exclusions..."
+cat $exclusionFileName | while read line || [ -n "$line" ]
 do
   if [ "${line:0:1}" != "#" ]; then
     echo "Evaluating RegEx \"$line\" for possible matching exclusions..."
     count=$(find ${targetDir} -regex ${line} | wc -l)
     if [ "$count" -ne "0" ]; then 
-      echo "Found the following file(s): "
+      echo "Found the following match(es): "
       find ${targetDir} -regex ${line}
       find ${targetDir} -regex ${line} | xargs rm -r
       echo "$count file(s) excluded."
     else
-      echo "No files were matched to be excluded."
+      echo "No file was matched to be excluded."
     fi
   fi
 done

--- a/exclude-files.sh
+++ b/exclude-files.sh
@@ -15,7 +15,7 @@ do
       find ${targetDir} -regex ${line} | xargs rm -r
       echo "$count file(s) excluded."
     else
-      echo "No file was matched to be excluded."
+      echo "No file matches the exclusion pattern."
     fi
   fi
 done

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <buildDirectory>${project.build.directory}</buildDirectory>
-    <assemblyClassifier/>
+    <assemblyClassifier />
   </properties>
   <dependencies>
     <dependency>
@@ -48,7 +48,7 @@
       </dependencies>
       <build>
         <plugins>
-           <plugin>
+          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-dependency-plugin</artifactId>
             <version>2.8</version>
@@ -76,13 +76,14 @@
             <executions>
               <execution>
                 <!-- Copy the non-prod target dir -->
-                <id>Copy non-prodcution files</id>
+                <id>Copy non-production files</id>
                 <phase>package</phase>
                 <goals>
                   <goal>copy-resources</goal>
                 </goals>
                 <configuration>
-                  <outputDirectory>${buildDirectory}/${project.artifactId}-${project.version}-${assemblyClassifier}</outputDirectory>
+                  <outputDirectory>
+                    ${buildDirectory}/${project.artifactId}-${project.version}-${assemblyClassifier}</outputDirectory>
                   <overwrite>true</overwrite>
                   <resources>
                     <resource>
@@ -91,22 +92,42 @@
                   </resources>
                 </configuration>
               </execution>
-                <execution>
+              <execution>
                 <!-- Overwrite non-prod configs with confidential configs -->
-                <!-- # Unknown -->
                 <id>Copy confidential configs</id>
                 <phase>package</phase>
                 <goals>
                   <goal>copy-resources</goal>
                 </goals>
                 <configuration>
-                  <outputDirectory>${buildDirectory}/${project.artifactId}-${project.version}-${assemblyClassifier}</outputDirectory>
+                  <outputDirectory>
+                    ${buildDirectory}/${project.artifactId}-${project.version}-${assemblyClassifier}</outputDirectory>
                   <overwrite>true</overwrite>
                   <resources>
                     <resource>
                       <directory>${buildDirectory}/ozone-config-cambodia0</directory>
                     </resource>
                   </resources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <!-- Exclude resource files as speficied in dependency-excludes-prod.txt -->
+          <plugin>
+            <artifactId>exec-maven-plugin</artifactId>
+            <version>3.1.0</version>
+            <groupId>org.codehaus.mojo</groupId>
+            <executions>
+              <execution>
+                <id>Run exclude-files.sh</id>
+                <phase>process-resources</phase>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <configuration>
+                  <executable>${basedir}/exclude-files.sh</executable>
+                  <commandlineArgs>${basedir}/dependency-excludes-${assemblyClassifier}.txt
+                    ${buildDirectory}/${project.artifactId}-${project.version}</commandlineArgs>
                 </configuration>
               </execution>
             </executions>
@@ -171,7 +192,8 @@
             </goals>
             <configuration>
               <executable>${basedir}/exclude-files.sh</executable>
-              <commandlineArgs>${buildDirectory}/${project.artifactId}-${project.version}</commandlineArgs>
+              <commandlineArgs>${basedir}/dependency-excludes.txt
+                ${buildDirectory}/${project.artifactId}-${project.version}</commandlineArgs>
             </configuration>
           </execution>
         </executions>

--- a/readme/impl-guide.md
+++ b/readme/impl-guide.md
@@ -13,12 +13,12 @@ $ cd ozone-distro-cambodia
 ```
 
 ## Manual instructions
-Build the distro (optional, provide a `prod` profile to include confidential configs)
+Build the distro (optional, provide a `prod` profile to include confidential configs and exclude demo artifacts)
 ```
 ./mvnw clean install [-Pprod]
 ```
 
-Prepare for the run (optional override the default `hostUrl` value - for Macs, provide a `prod` profile)
+Prepare for the run (optional, provide a `prod` profile to use the previously built `prod` distribution)
 ```
 ./mvnw -f run/pom.xml clean package [-Pprod]
 ```


### PR DESCRIPTION
https://issues.openmrs.org/projects/KH/issues/KH-155

Excluding the Reference Demo Data module by calling the **exclude-files.sh** with a prod-specific list of exlcusions, only when running `prod` profile. This script appears very handy afterall.