### PR TITLE
KH-129: Hide Capture image button from the patient registration form

### DIFF
--- a/configs/ozone_config/frontend/ozone-frontend-config.json
+++ b/configs/ozone_config/frontend/ozone-frontend-config.json
@@ -7,6 +7,9 @@
       ],
       "fieldConfigurations":
       {
+        "name": {
+          "displayCapturePhoto": false
+        },
         "gender": [
           {
             "id": "male",


### PR DESCRIPTION
## Summary
Hides the capture image button from the patient registration form.

## Screenshots
![image](https://user-images.githubusercontent.com/51502471/234821590-2a4574d0-7986-43de-9844-cba75396c794.png)

## Related issue
https://issues.openmrs.org/browse/KH-129
