### PR TITLE
Remove empty section from the NCD Medical history form

### DIFF
--- a/configs/openmrs_config/ampathforms/NCD_Medical_History.json
+++ b/configs/openmrs_config/ampathforms/NCD_Medical_History.json
@@ -10,12 +10,6 @@
     "referencedForms": [],
     "pages": [
         {
-            "label": "General",
-            "sections": [
-                {}
-            ]
-        },
-        {
             "label": "Medical History",
             "sections": [
                 {


### PR DESCRIPTION
Description → Fixed the issue of NCD Medical History form failing to load the form content

[medicalForm.webm](https://github.com/openmrs/ozone-distro-cambodia/assets/38831673/8fe1c235-0b4f-4b09-a126-162b8ef3fad4)
