### PR TITLE
OZ-678: Update `ozone/` to `configs/` for serving frontend configs

### DIFF
--- a/base/configs/openmrs/frontend_config/ozone-frontend-config.json
+++ b/base/configs/openmrs/frontend_config/ozone-frontend-config.json
@@ -204,7 +204,7 @@
       }
     },
     "logo": {
-      "src": "ozone/emr_logo_small_not_bold.png",
+      "src": "configs/emr_logo_small_not_bold.png",
       "alt": "emr-logo"
     },
     "Display conditions": {
@@ -387,13 +387,13 @@
   },
   "@openmrs/esm-login-app": {
     "logo": {
-      "src": "ozone/emr_logo_color.png",
+      "src": "configs/emr_logo_color.png",
       "alt": "emr-logo"
     }
   },
   "@openmrs/esm-primary-navigation-app": {
     "logo": {
-      "src": "ozone/emr_logo_small_not_bold.png",
+      "src": "configs/emr_logo_small_not_bold.png",
       "alt": "emr-logo"
     },
     "Translation overrides": {


### PR DESCRIPTION
Issue: https://mekomsolutions.atlassian.net/jira/software/c/projects/OZ/issues/OZ-698

This PR updates `ozone/` to `configs/` because frontend assets/configs is now served at `/configs`